### PR TITLE
Modernize visuals with AI, accessibility and medical motion

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -82,15 +82,20 @@
         <div class="top-nav-container">
             <div class="nav-brand">
                 <a href="index.html" class="brand-link">
-                    <div class="ai-logo" role="img" aria-label="AI-themed logo">
-                        <div class="neural-network-icon">
-                            <div class="node"></div>
-                            <div class="node"></div>
-                            <div class="node"></div>
-                            <div class="connection"></div>
-                            <div class="connection"></div>
-                        </div>
-                    </div>
+                    <span class="ai-logo" role="img" aria-label="Neural network logo">
+                        <svg class="ai-logo__svg" viewBox="0 0 40 40" focusable="false" aria-hidden="true">
+                            <g class="ai-logo__links">
+                                <line x1="20" y1="9" x2="10" y2="30" pathLength="100" />
+                                <line x1="20" y1="9" x2="30" y2="30" pathLength="100" />
+                                <line x1="10" y1="30" x2="30" y2="30" pathLength="100" />
+                            </g>
+                            <g class="ai-logo__nodes">
+                                <circle cx="20" cy="9" r="4" />
+                                <circle cx="10" cy="30" r="4" />
+                                <circle cx="30" cy="30" r="4" />
+                            </g>
+                        </svg>
+                    </span>
                     <span class="brand-text">Aydin Ayanzadeh</span>
                 </a>
             </div>

--- a/css/style.css
+++ b/css/style.css
@@ -6402,3 +6402,78 @@ img[loading="lazy"].loaded {
 .ai-text {
     background-image: linear-gradient(135deg, #ffffff 0%, #e0f2fe 45%, #93c5fd 100%);
 }
+
+/* --------------------------------------------------------------------------
+   Research at a glance — a metrics band bridging the dark hero and the
+   light About section. Each tile links to the section it counts, so the
+   figure is verifiable in one click.
+   -------------------------------------------------------------------------- */
+
+.metrics-band {
+    width: 100%;
+    padding: 36px 0;
+    background: var(--background-light);
+    border-bottom: 1px solid var(--border-color);
+    position: relative;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 160px), 1fr));
+    gap: 12px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.metric {
+    text-align: center;
+}
+
+.metric__link {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 14px 10px;
+    border-radius: 12px;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.25s ease, transform 0.25s var(--ease-out-soft);
+}
+
+.metric__link:hover,
+.metric__link:focus-visible {
+    background: var(--accent-soft);
+    transform: translateY(-2px);
+}
+
+.metric__value {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    background-image: var(--section-title-gradient);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    /* Digits change width as the counter runs; tabular figures stop the
+       label beneath from shuffling sideways. */
+    font-variant-numeric: tabular-nums;
+}
+
+.metric__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-light);
+}
+
+/* Separators between tiles, dropped once the grid wraps to one column. */
+@media (min-width: 641px) {
+    .metric + .metric {
+        border-left: 1px solid var(--border-color);
+    }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -445,63 +445,6 @@ section,
     height: 40px;
 }
 
-.neural-network-icon {
-    position: relative;
-    width: 100%;
-    height: 100%;
-}
-
-.neural-network-icon .node {
-    position: absolute;
-    width: 8px;
-    height: 8px;
-    background: var(--primary-color);
-    border-radius: 50%;
-    animation: pulse 2s infinite;
-}
-
-.neural-network-icon .node:nth-child(1) {
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    animation-delay: 0s;
-}
-
-.neural-network-icon .node:nth-child(2) {
-    top: 50%;
-    left: 0;
-    transform: translateY(-50%);
-    animation-delay: 0.5s;
-}
-
-.neural-network-icon .node:nth-child(3) {
-    top: 50%;
-    right: 0;
-    transform: translateY(-50%);
-    animation-delay: 1s;
-}
-
-.neural-network-icon .connection {
-    position: absolute;
-    height: 2px;
-    background: linear-gradient(90deg, var(--primary-color), transparent);
-    animation: dataFlow 3s infinite;
-}
-
-.neural-network-icon .connection:nth-child(4) {
-    top: 25%;
-    left: 25%;
-    width: 50%;
-    transform: rotate(45deg);
-}
-
-.neural-network-icon .connection:nth-child(5) {
-    top: 25%;
-    right: 25%;
-    width: 50%;
-    transform: rotate(-45deg);
-}
-
 .brand-text {
     font-size: 1.5rem;
     font-weight: 700;
@@ -680,178 +623,6 @@ button.theme-toggle-btn {
     opacity: 0.15;
     z-index: 0;
     pointer-events: none;
-}
-
-/* AI Background Animation */
-.ai-background {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-}
-
-.neural-network {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 80%;
-    height: 80%;
-    opacity: 0.1;
-}
-
-.neural-layer {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-}
-
-.neural-layer.layer-1 {
-    top: 0;
-    animation: neuralPulse 4s ease-in-out infinite;
-}
-
-.neural-layer.layer-2 {
-    top: 30%;
-    animation: neuralPulse 4s ease-in-out infinite 1s;
-}
-
-.neural-layer.layer-3 {
-    top: 60%;
-    animation: neuralPulse 4s ease-in-out infinite 2s;
-}
-
-.neuron {
-    position: absolute;
-    width: 12px;
-    height: 12px;
-    background: var(--primary-color);
-    border-radius: 50%;
-    box-shadow: 0 0 20px var(--primary-color);
-    /* Pulse via opacity/transform only — keeps the animation on the compositor */
-    animation: neuronGlow 3s ease-in-out infinite;
-    will-change: opacity, transform;
-}
-
-.neural-layer.layer-1 .neuron:nth-child(1) {
-    top: 0;
-    left: 20%;
-}
-
-.neural-layer.layer-1 .neuron:nth-child(2) {
-    top: 0;
-    left: 40%;
-}
-
-.neural-layer.layer-1 .neuron:nth-child(3) {
-    top: 0;
-    left: 60%;
-}
-
-.neural-layer.layer-1 .neuron:nth-child(4) {
-    top: 0;
-    left: 80%;
-}
-
-.neural-layer.layer-2 .neuron:nth-child(1) {
-    top: 0;
-    left: 10%;
-}
-
-.neural-layer.layer-2 .neuron:nth-child(2) {
-    top: 0;
-    left: 30%;
-}
-
-.neural-layer.layer-2 .neuron:nth-child(3) {
-    top: 0;
-    left: 50%;
-}
-
-.neural-layer.layer-2 .neuron:nth-child(4) {
-    top: 0;
-    left: 70%;
-}
-
-.neural-layer.layer-2 .neuron:nth-child(5) {
-    top: 0;
-    left: 90%;
-}
-
-.neural-layer.layer-3 .neuron:nth-child(1) {
-    top: 0;
-    left: 25%;
-}
-
-.neural-layer.layer-3 .neuron:nth-child(2) {
-    top: 0;
-    left: 50%;
-}
-
-.neural-layer.layer-3 .neuron:nth-child(3) {
-    top: 0;
-    left: 75%;
-}
-
-.data-particles {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-}
-
-.particle {
-    position: absolute;
-    width: 4px;
-    height: 4px;
-    background: var(--primary-color);
-    border-radius: 50%;
-    animation: particleFloat 6s linear infinite;
-}
-
-/* Varied sizes and speeds give the particle field a sense of depth */
-.particle:nth-child(1) {
-    top: 20%;
-    left: 10%;
-    animation-delay: 0s;
-    animation-duration: 7s;
-}
-
-.particle:nth-child(2) {
-    top: 40%;
-    left: 80%;
-    width: 5px;
-    height: 5px;
-    animation-delay: 1s;
-    animation-duration: 9s;
-}
-
-.particle:nth-child(3) {
-    top: 60%;
-    left: 20%;
-    width: 3px;
-    height: 3px;
-    animation-delay: 2s;
-    animation-duration: 6s;
-}
-
-.particle:nth-child(4) {
-    top: 80%;
-    left: 70%;
-    width: 5px;
-    height: 5px;
-    animation-delay: 3s;
-    animation-duration: 10s;
-}
-
-.particle:nth-child(5) {
-    top: 30%;
-    left: 50%;
-    width: 3px;
-    height: 3px;
-    animation-delay: 4s;
-    animation-duration: 7.5s;
 }
 
 .hero>.container {
@@ -4680,70 +4451,6 @@ img[loading="lazy"].loaded {
 }
 
 /* AI-Themed Animations */
-@keyframes neuralPulse {
-
-    0%,
-    100% {
-        opacity: 0.1;
-        transform: scale(1);
-    }
-
-    50% {
-        opacity: 0.3;
-        transform: scale(1.05);
-    }
-}
-
-@keyframes neuronGlow {
-
-    0%,
-    100% {
-        opacity: 0.7;
-        transform: scale(1);
-    }
-
-    50% {
-        opacity: 1;
-        transform: scale(1.15);
-    }
-}
-
-@keyframes dataFlow {
-    0% {
-        opacity: 0;
-        transform: translateX(-100%);
-    }
-
-    50% {
-        opacity: 1;
-    }
-
-    100% {
-        opacity: 0;
-        transform: translateX(100%);
-    }
-}
-
-@keyframes particleFloat {
-    0% {
-        transform: translateY(0) translateX(0);
-        opacity: 0;
-    }
-
-    10% {
-        opacity: 1;
-    }
-
-    90% {
-        opacity: 1;
-    }
-
-    100% {
-        transform: translateY(-100vh) translateX(50px);
-        opacity: 0;
-    }
-}
-
 /* Hero entrance — one-time staggered reveal.
    Only "from" is defined so the animation releases the transform/opacity
    properties once it finishes (keeps hover transforms working afterwards). */
@@ -6074,4 +5781,631 @@ img[loading="lazy"].loaded {
 
 [data-theme="light"] .footer {
     background: var(--secondary-color);
+}
+
+/* ==========================================================================
+   MOTION SYSTEM — AI / ACCESSIBILITY / MEDICAL IMAGING
+   --------------------------------------------------------------------------
+   Every animation below follows one rule: the *base* style is the resting
+   state and the keyframes supply the movement. That way the site-wide
+   `prefers-reduced-motion` / `body.reduce-motion` overrides (which collapse
+   animation-duration to 0.01ms) leave a sensible static picture behind
+   instead of freezing an element mid-transition or hiding it entirely.
+   None of these animations use a fill-mode, for the same reason.
+   ========================================================================== */
+
+:root {
+    /* Signal blues for the neural graph, monitor green for the vitals trace,
+       ember orange for the wildfire glyph. */
+    --signal-color: #38bdf8;
+    --signal-strong: #bae6fd;
+    --signal-faint: rgba(148, 197, 255, 0.16);
+    --vital-color: #34d399;
+    --vital-faint: rgba(125, 211, 252, 0.2);
+    --ember-color: #fb923c;
+    --ember-core: #fde68a;
+}
+
+:root[data-theme="dark"] {
+    --signal-faint: rgba(148, 197, 255, 0.22);
+    --vital-faint: rgba(125, 211, 252, 0.16);
+}
+
+/* --------------------------------------------------------------------------
+   Hero: layered neural graph over a heartbeat trace
+   -------------------------------------------------------------------------- */
+
+.hero-viz {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+/* Paused by the IntersectionObserver once the hero scrolls away, and while
+   the tab is hidden — no point repainting a graph nobody is looking at. */
+.hero-viz.is-paused *,
+.hero-viz.is-paused {
+    animation-play-state: paused;
+}
+
+.hero-net {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.55;
+}
+
+.hero-net__edges line {
+    stroke: var(--signal-faint);
+    stroke-width: 1;
+}
+
+/* A short dash whose pattern period equals pathLength, so travelling the
+   offset from 100 to 0 walks the dot from one node to the next and loops
+   without a visible seam. */
+.hero-net__pulses line {
+    stroke: var(--signal-strong);
+    stroke-width: 2.4;
+    stroke-linecap: round;
+    stroke-dasharray: 7 93;
+    stroke-dashoffset: 100;
+    opacity: 0;
+    animation: synapseTravel 4.8s linear infinite;
+}
+
+@keyframes synapseTravel {
+    0% {
+        stroke-dashoffset: 100;
+        opacity: 0;
+    }
+
+    12% {
+        opacity: 0.9;
+    }
+
+    78% {
+        opacity: 0.9;
+    }
+
+    100% {
+        stroke-dashoffset: 0;
+        opacity: 0;
+    }
+}
+
+.hero-net__halo {
+    fill: none;
+    stroke: var(--signal-color);
+    stroke-width: 1.25;
+    opacity: 0.12;
+    animation: nodeHalo 5.4s ease-in-out infinite;
+}
+
+@keyframes nodeHalo {
+    0%,
+    100% {
+        opacity: 0.08;
+    }
+
+    50% {
+        opacity: 0.3;
+    }
+}
+
+.hero-net__core {
+    r: 4;
+    fill: #dbeafe;
+    opacity: 0.75;
+    animation: nodeBreathe 5.4s ease-in-out infinite;
+}
+
+@keyframes nodeBreathe {
+    0%,
+    100% {
+        opacity: 0.45;
+    }
+
+    50% {
+        opacity: 1;
+    }
+}
+
+/* Sits above the scroll indicator rather than flush with the hero's bottom
+   edge, so the trace is never the part that gets cropped. */
+.hero-ecg {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 8%;
+    width: 100%;
+    height: clamp(80px, 13vh, 140px);
+}
+
+.hero-ecg path {
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vector-effect: non-scaling-stroke;
+}
+
+.hero-ecg__base {
+    stroke: var(--vital-faint);
+    stroke-width: 1.5;
+}
+
+/* Resting state is invisible: with motion reduced only the faint base trace
+   remains, which is the calm version of the same picture. */
+.hero-ecg__sweep {
+    stroke: var(--vital-color);
+    stroke-width: 2.25;
+    stroke-dasharray: 170 1030;
+    stroke-dashoffset: 1200;
+    opacity: 0;
+    animation: vitalSweep 7.5s linear infinite;
+}
+
+@keyframes vitalSweep {
+    0% {
+        stroke-dashoffset: 1200;
+        opacity: 0.85;
+    }
+
+    100% {
+        stroke-dashoffset: 0;
+        opacity: 0.85;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   Vitals divider — a quiet section break on the medical theme
+   -------------------------------------------------------------------------- */
+
+.vitals-divider {
+    width: 100%;
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 24px;
+    line-height: 0;
+}
+
+.vitals-divider svg {
+    width: 100%;
+    height: 56px;
+    display: block;
+}
+
+.vitals-divider path {
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vector-effect: non-scaling-stroke;
+}
+
+.vitals-divider__base {
+    stroke: var(--border-color);
+    stroke-width: 1.5;
+}
+
+.vitals-divider__sweep {
+    stroke: var(--primary-light);
+    stroke-width: 2.25;
+    stroke-dasharray: 150 1050;
+    stroke-dashoffset: 1200;
+    opacity: 0;
+    animation: vitalSweep 9s linear infinite;
+}
+
+/* --------------------------------------------------------------------------
+   Navigation brand mark — three neurons firing in sequence
+   -------------------------------------------------------------------------- */
+
+.ai-logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    flex: 0 0 auto;
+}
+
+.ai-logo__svg {
+    width: 100%;
+    height: 100%;
+}
+
+.ai-logo__links line {
+    stroke: var(--primary-color);
+    stroke-width: 2;
+    stroke-linecap: round;
+    opacity: 0.3;
+    animation: logoSignal 3s ease-in-out infinite;
+}
+
+.ai-logo__links line:nth-child(2) {
+    animation-delay: 0.35s;
+}
+
+.ai-logo__links line:nth-child(3) {
+    animation-delay: 0.7s;
+}
+
+@keyframes logoSignal {
+    0%,
+    55%,
+    100% {
+        opacity: 0.22;
+    }
+
+    22% {
+        opacity: 0.95;
+    }
+}
+
+.ai-logo__nodes circle {
+    fill: var(--primary-color);
+    animation: nodeBreathe 3s ease-in-out infinite;
+}
+
+.ai-logo__nodes circle:nth-child(2) {
+    animation-delay: 0.35s;
+}
+
+.ai-logo__nodes circle:nth-child(3) {
+    animation-delay: 0.7s;
+}
+
+/* --------------------------------------------------------------------------
+   Research pillar glyphs (About → Current Focus)
+   -------------------------------------------------------------------------- */
+
+.focus-glyph {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 46px;
+    margin-top: 2px;
+    border-radius: 13px;
+    background: var(--accent-soft);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.focus-item:hover .focus-glyph {
+    background: rgba(37, 99, 235, 0.18);
+    border-color: var(--primary-light);
+}
+
+.focus-glyph svg {
+    width: 30px;
+    height: 30px;
+}
+
+/* Sonar rings — spatial guidance for blind and low-vision travellers.
+   `r` is animated rather than a transform so no transform-box is needed. */
+.focus-glyph__rings circle {
+    fill: none;
+    stroke: var(--primary-color);
+    stroke-width: 2;
+    opacity: 0.25;
+    animation: sonarPing 2.4s ease-out infinite;
+}
+
+@keyframes sonarPing {
+    0% {
+        r: 5;
+        opacity: 0;
+    }
+
+    25% {
+        opacity: 0.6;
+    }
+
+    100% {
+        r: 21;
+        opacity: 0;
+    }
+}
+
+/* The figure is the international access symbol rather than a cane, which at
+   30px was indistinguishable from a clock hand. */
+.focus-glyph__figure circle {
+    fill: var(--primary-dark);
+}
+
+.focus-glyph__figure path {
+    fill: none;
+    stroke: var(--primary-dark);
+    stroke-width: 2.4;
+    stroke-linecap: round;
+}
+
+/* Wildfire — flicker via opacity only, embers rise by translation. Both are
+   origin-independent, so they behave the same in every engine. */
+.focus-glyph__flame {
+    fill: var(--ember-color);
+    opacity: 0.85;
+    animation: flameFlicker 2.4s ease-in-out infinite;
+}
+
+.focus-glyph__flame-core {
+    fill: var(--ember-core);
+    opacity: 0.9;
+    animation: flameFlicker 1.7s ease-in-out infinite reverse;
+}
+
+@keyframes flameFlicker {
+    0%,
+    100% {
+        opacity: 0.7;
+    }
+
+    40% {
+        opacity: 1;
+    }
+
+    70% {
+        opacity: 0.82;
+    }
+}
+
+.focus-glyph__embers circle {
+    fill: var(--ember-color);
+    opacity: 0;
+    animation: emberRise 2.9s ease-out infinite;
+}
+
+@keyframes emberRise {
+    0% {
+        transform: translateY(4px);
+        opacity: 0;
+    }
+
+    20% {
+        opacity: 0.9;
+    }
+
+    100% {
+        transform: translateY(-24px);
+        opacity: 0;
+    }
+}
+
+/* Medical monitor — the trace draws itself in and out while a scan line
+   sweeps the frame, the way a segmentation model walks an image. */
+.focus-glyph__monitor {
+    fill: none;
+    stroke: rgba(37, 99, 235, 0.35);
+    stroke-width: 2;
+}
+
+.focus-glyph__trace {
+    fill: none;
+    stroke: var(--vital-color);
+    stroke-width: 2.4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 100;
+    stroke-dashoffset: 0;
+    animation: traceDraw 3s ease-in-out infinite;
+}
+
+/* Holds the completed trace for a third of the cycle — otherwise a glance at
+   the card catches a half-drawn line more often than the finished one. */
+@keyframes traceDraw {
+    0% {
+        stroke-dashoffset: 100;
+    }
+
+    34%,
+    68% {
+        stroke-dashoffset: 0;
+    }
+
+    100% {
+        stroke-dashoffset: -100;
+    }
+}
+
+.focus-glyph__scanline {
+    stroke: var(--signal-color);
+    stroke-width: 2;
+    stroke-linecap: round;
+    opacity: 0;
+    animation: scanSweep 3.6s ease-in-out infinite;
+}
+
+@keyframes scanSweep {
+    0% {
+        transform: translateY(2px);
+        opacity: 0;
+    }
+
+    18% {
+        opacity: 0.85;
+    }
+
+    82% {
+        opacity: 0.85;
+    }
+
+    100% {
+        transform: translateY(28px);
+        opacity: 0;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   Reading progress — a decorative mirror of the scrollbar, driven from JS
+   -------------------------------------------------------------------------- */
+
+.scroll-progress {
+    position: fixed;
+    top: var(--nav-height);
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 1000;
+    pointer-events: none;
+}
+
+.scroll-progress__bar {
+    display: block;
+    width: 100%;
+    height: 100%;
+    transform: scaleX(0);
+    transform-origin: left center;
+    background: linear-gradient(90deg, var(--primary-color), var(--signal-color) 55%, var(--vital-color));
+    will-change: transform;
+}
+
+/* --------------------------------------------------------------------------
+   Navigation underline
+   -------------------------------------------------------------------------- */
+
+.top-nav-link {
+    position: relative;
+}
+
+.top-nav-link::after {
+    content: '';
+    position: absolute;
+    left: 10px;
+    right: 10px;
+    bottom: 2px;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--section-title-gradient);
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.28s var(--ease-out-expo);
+}
+
+.top-nav-link:hover::after,
+.top-nav-link:focus-visible::after,
+.top-nav-link.active::after {
+    transform: scaleX(1);
+}
+
+.theme-toggle-btn::after {
+    content: none;
+}
+
+/* --------------------------------------------------------------------------
+   Card scan sweep — a soft band of light crosses the card on hover, echoing
+   an imaging pass. Pointer-only: touch devices get no hover state to trigger.
+   -------------------------------------------------------------------------- */
+
+@media (hover: hover) and (pointer: fine) {
+    .publication-item,
+    .experience-card,
+    .project-item,
+    .project-card,
+    .news-card,
+    .award-item {
+        position: relative;
+        overflow: hidden;
+    }
+
+    .publication-item::after,
+    .experience-card::after,
+    .project-item::after,
+    .project-card::after,
+    .news-card::after,
+    .award-item::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+        pointer-events: none;
+        background: linear-gradient(115deg,
+                transparent 38%,
+                rgba(56, 189, 248, 0.16) 50%,
+                transparent 62%);
+        opacity: 0;
+        transform: translateX(-55%);
+        transition: opacity 0.25s ease, transform 0.8s var(--ease-out-expo);
+    }
+
+    .publication-item:hover::after,
+    .experience-card:hover::after,
+    .project-item:hover::after,
+    .project-card:hover::after,
+    .news-card:hover::after,
+    .award-item:hover::after {
+        opacity: 1;
+        transform: translateX(55%);
+    }
+
+    /* A sweep that cannot travel is just a tint over the card, so drop it
+       entirely when motion is reduced. */
+    body.reduce-motion .publication-item::after,
+    body.reduce-motion .experience-card::after,
+    body.reduce-motion .project-item::after,
+    body.reduce-motion .project-card::after,
+    body.reduce-motion .news-card::after,
+    body.reduce-motion .award-item::after {
+        content: none;
+    }
+}
+
+@media (hover: hover) and (pointer: fine) and (prefers-reduced-motion: reduce) {
+    .publication-item::after,
+    .experience-card::after,
+    .project-item::after,
+    .project-card::after,
+    .news-card::after,
+    .award-item::after {
+        content: none;
+    }
+}
+
+/* Card content sits above the sweep layer. */
+.publication-item > *,
+.experience-card > *,
+.project-item > *,
+.project-card > *,
+.news-card > *,
+.award-item > * {
+    position: relative;
+    z-index: 1;
+}
+
+/* --------------------------------------------------------------------------
+   Layout corrections that surfaced while fitting the new visuals
+   -------------------------------------------------------------------------- */
+
+/* .main-content is offset by the fixed navbar, so a 100vh hero always
+   overflowed the viewport by exactly the navbar's height — which pushed the
+   scroll indicator and the heartbeat trace below the fold on first paint. */
+.hero {
+    min-height: calc(100vh - var(--nav-height));
+}
+
+@supports (min-height: 100svh) {
+    .hero {
+        min-height: calc(100svh - var(--nav-height));
+    }
+}
+
+/* Three research pillars now fit on one row inside the About panel instead of
+   wrapping 2 + 1. */
+.focus-items {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr));
+    gap: 20px;
+}
+
+/* The old white → mid-blue gradient dropped the second line of the name to
+   roughly 3:1 against the navy hero. Keeping the sheen in the light end of
+   the ramp holds the contrast up.
+
+   Note background-image rather than the background shorthand: the shorthand
+   resets background-clip to border-box, which paints the gradient as a solid
+   block over the text it is supposed to be clipped to. */
+.ai-text {
+    background-image: linear-gradient(135deg, #ffffff 0%, #e0f2fe 45%, #93c5fd 100%);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -589,12 +589,22 @@ button.theme-toggle-btn {
     text-align: center;
     position: relative;
     overflow: hidden;
-    min-height: 100vh;
+    /* .main-content is offset by the fixed navbar, so a plain 100vh overflowed
+       the viewport by exactly the navbar's height and pushed the scroll
+       indicator below the fold. Declared here rather than appended later so
+       the `min-height: auto` mobile override further down still wins. */
+    min-height: calc(100vh - var(--nav-height));
     display: flex;
     align-items: center;
     justify-content: center;
     margin: 0;
     box-sizing: border-box;
+}
+
+@supports (min-height: 100svh) {
+    .hero {
+        min-height: calc(100svh - var(--nav-height));
+    }
 }
 
 .hero::before {
@@ -6306,9 +6316,12 @@ img[loading="lazy"].loaded {
     .project-item,
     .project-card,
     .news-card,
-    .award-item {
+    .award-item:not(.featured-award) {
         position: relative;
         overflow: hidden;
+        /* Confines the sweep's negative z-index to this card, so it paints
+           over the card's own background rather than behind it. */
+        isolation: isolate;
     }
 
     .publication-item::after,
@@ -6316,11 +6329,14 @@ img[loading="lazy"].loaded {
     .project-item::after,
     .project-card::after,
     .news-card::after,
-    .award-item::after {
+    .award-item:not(.featured-award)::after {
         content: '';
         position: absolute;
         inset: 0;
-        z-index: 0;
+        /* Behind the card's content, not above it. Promoting every direct
+           child with `position: relative` instead would knock the absolutely
+           positioned corner badges into the text flow. */
+        z-index: -1;
         pointer-events: none;
         background: linear-gradient(115deg,
                 transparent 38%,
@@ -6336,7 +6352,7 @@ img[loading="lazy"].loaded {
     .project-item:hover::after,
     .project-card:hover::after,
     .news-card:hover::after,
-    .award-item:hover::after {
+    .award-item:not(.featured-award):hover::after {
         opacity: 1;
         transform: translateX(55%);
     }
@@ -6348,7 +6364,7 @@ img[loading="lazy"].loaded {
     body.reduce-motion .project-item::after,
     body.reduce-motion .project-card::after,
     body.reduce-motion .news-card::after,
-    body.reduce-motion .award-item::after {
+    body.reduce-motion .award-item:not(.featured-award)::after {
         content: none;
     }
 }
@@ -6359,38 +6375,15 @@ img[loading="lazy"].loaded {
     .project-item::after,
     .project-card::after,
     .news-card::after,
-    .award-item::after {
+    .award-item:not(.featured-award)::after {
         content: none;
     }
 }
 
-/* Card content sits above the sweep layer. */
-.publication-item > *,
-.experience-card > *,
-.project-item > *,
-.project-card > *,
-.news-card > *,
-.award-item > * {
-    position: relative;
-    z-index: 1;
-}
 
 /* --------------------------------------------------------------------------
    Layout corrections that surfaced while fitting the new visuals
    -------------------------------------------------------------------------- */
-
-/* .main-content is offset by the fixed navbar, so a 100vh hero always
-   overflowed the viewport by exactly the navbar's height — which pushed the
-   scroll indicator and the heartbeat trace below the fold on first paint. */
-.hero {
-    min-height: calc(100vh - var(--nav-height));
-}
-
-@supports (min-height: 100svh) {
-    .hero {
-        min-height: calc(100svh - var(--nav-height));
-    }
-}
 
 /* Three research pillars now fit on one row inside the About panel instead of
    wrapping 2 + 1. */

--- a/index.html
+++ b/index.html
@@ -213,20 +213,30 @@
     <!-- Skip to Content for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
 
+    <!-- Reading progress: decorative mirror of the scrollbar, so it stays out of the a11y tree -->
+    <div class="scroll-progress" aria-hidden="true">
+        <span class="scroll-progress__bar" id="scroll-progress-bar"></span>
+    </div>
+
     <!-- Enhanced Top Navigation -->
     <nav class="top-navbar" role="navigation" aria-label="Main navigation" id="main-navigation">
         <div class="top-nav-container">
             <div class="nav-brand">
                 <a href="#home" class="brand-link" aria-label="Aydin Ayanzadeh - Go to home section">
-                    <div class="ai-logo" role="img" aria-label="AI-themed logo with neural network design">
-                        <div class="neural-network-icon">
-                            <div class="node" aria-hidden="true"></div>
-                            <div class="node" aria-hidden="true"></div>
-                            <div class="node" aria-hidden="true"></div>
-                            <div class="connection" aria-hidden="true"></div>
-                            <div class="connection" aria-hidden="true"></div>
-                        </div>
-                    </div>
+                    <span class="ai-logo" role="img" aria-label="Neural network logo">
+                        <svg class="ai-logo__svg" viewBox="0 0 40 40" focusable="false" aria-hidden="true">
+                            <g class="ai-logo__links">
+                                <line x1="20" y1="9" x2="10" y2="30" pathLength="100" />
+                                <line x1="20" y1="9" x2="30" y2="30" pathLength="100" />
+                                <line x1="10" y1="30" x2="30" y2="30" pathLength="100" />
+                            </g>
+                            <g class="ai-logo__nodes">
+                                <circle cx="20" cy="9" r="4" />
+                                <circle cx="10" cy="30" r="4" />
+                                <circle cx="30" cy="30" r="4" />
+                            </g>
+                        </svg>
+                    </span>
                     <span class="brand-text">Aydin Ayanzadeh</span>
                 </a>
             </div>
@@ -276,35 +286,98 @@
     <main class="main-content" id="main-content">
         <!-- Enhanced AI-Themed Hero Section -->
         <section id="home" class="hero" aria-label="Introduction">
-            <!-- AI Background Animation -->
-            <div class="ai-background">
-                <div class="neural-network">
-                    <div class="neural-layer layer-1">
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                    </div>
-                    <div class="neural-layer layer-2">
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                    </div>
-                    <div class="neural-layer layer-3">
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                        <div class="neuron"></div>
-                    </div>
-                </div>
-                <div class="data-particles">
-                    <div class="particle"></div>
-                    <div class="particle"></div>
-                    <div class="particle"></div>
-                    <div class="particle"></div>
-                    <div class="particle"></div>
-                </div>
+            <!-- Decorative visualization: a layered neural network carrying signal
+                 pulses, over a heartbeat trace. Presentational only. -->
+            <div class="ai-background hero-viz" aria-hidden="true">
+                <svg class="hero-net" viewBox="0 0 1200 560" preserveAspectRatio="xMidYMid meet"
+                    focusable="false" role="presentation">
+                    <g class="hero-net__edges">
+                        <line x1="150" y1="120" x2="450" y2="80" />
+                        <line x1="150" y1="120" x2="450" y2="190" />
+                        <line x1="150" y1="120" x2="450" y2="300" />
+                        <line x1="150" y1="240" x2="450" y2="190" />
+                        <line x1="150" y1="240" x2="450" y2="300" />
+                        <line x1="150" y1="240" x2="450" y2="410" />
+                        <line x1="150" y1="360" x2="450" y2="300" />
+                        <line x1="150" y1="360" x2="450" y2="410" />
+                        <line x1="150" y1="360" x2="450" y2="500" />
+                        <line x1="150" y1="470" x2="450" y2="300" />
+                        <line x1="150" y1="470" x2="450" y2="410" />
+                        <line x1="150" y1="470" x2="450" y2="500" />
+                        <line x1="450" y1="80" x2="760" y2="130" />
+                        <line x1="450" y1="80" x2="760" y2="250" />
+                        <line x1="450" y1="190" x2="760" y2="130" />
+                        <line x1="450" y1="190" x2="760" y2="250" />
+                        <line x1="450" y1="190" x2="760" y2="370" />
+                        <line x1="450" y1="300" x2="760" y2="250" />
+                        <line x1="450" y1="300" x2="760" y2="370" />
+                        <line x1="450" y1="410" x2="760" y2="250" />
+                        <line x1="450" y1="410" x2="760" y2="370" />
+                        <line x1="450" y1="410" x2="760" y2="470" />
+                        <line x1="450" y1="500" x2="760" y2="370" />
+                        <line x1="450" y1="500" x2="760" y2="470" />
+                        <line x1="760" y1="130" x2="1050" y2="220" />
+                        <line x1="760" y1="130" x2="1050" y2="340" />
+                        <line x1="760" y1="250" x2="1050" y2="220" />
+                        <line x1="760" y1="250" x2="1050" y2="340" />
+                        <line x1="760" y1="370" x2="1050" y2="220" />
+                        <line x1="760" y1="370" x2="1050" y2="340" />
+                        <line x1="760" y1="470" x2="1050" y2="220" />
+                        <line x1="760" y1="470" x2="1050" y2="340" />
+                    </g>
+                    <g class="hero-net__pulses">
+                        <line x1="150" y1="120" x2="450" y2="80" pathLength="100" style="animation-delay: 0s" />
+                        <line x1="150" y1="240" x2="450" y2="300" pathLength="100" style="animation-delay: 1.1s" />
+                        <line x1="150" y1="360" x2="450" y2="500" pathLength="100" style="animation-delay: 2.3s" />
+                        <line x1="150" y1="470" x2="450" y2="500" pathLength="100" style="animation-delay: 3.1s" />
+                        <line x1="450" y1="80" x2="760" y2="250" pathLength="100" style="animation-delay: 0.6s" />
+                        <line x1="450" y1="300" x2="760" y2="370" pathLength="100" style="animation-delay: 1.8s" />
+                        <line x1="450" y1="410" x2="760" y2="470" pathLength="100" style="animation-delay: 2.8s" />
+                        <line x1="450" y1="500" x2="760" y2="470" pathLength="100" style="animation-delay: 3.7s" />
+                        <line x1="760" y1="130" x2="1050" y2="340" pathLength="100" style="animation-delay: 1.3s" />
+                        <line x1="760" y1="370" x2="1050" y2="220" pathLength="100" style="animation-delay: 2.1s" />
+                        <line x1="760" y1="470" x2="1050" y2="220" pathLength="100" style="animation-delay: 3.4s" />
+                    </g>
+                    <g class="hero-net__nodes">
+                        <circle class="hero-net__halo" cx="150" cy="120" r="15" style="animation-delay: 0.00s" />
+                        <circle class="hero-net__halo" cx="150" cy="240" r="15" style="animation-delay: 0.37s" />
+                        <circle class="hero-net__halo" cx="150" cy="360" r="15" style="animation-delay: 0.74s" />
+                        <circle class="hero-net__halo" cx="150" cy="470" r="15" style="animation-delay: 1.11s" />
+                        <circle class="hero-net__halo" cx="450" cy="80" r="15" style="animation-delay: 1.48s" />
+                        <circle class="hero-net__halo" cx="450" cy="190" r="15" style="animation-delay: 1.85s" />
+                        <circle class="hero-net__halo" cx="450" cy="300" r="15" style="animation-delay: 2.22s" />
+                        <circle class="hero-net__halo" cx="450" cy="410" r="15" style="animation-delay: 2.59s" />
+                        <circle class="hero-net__halo" cx="450" cy="500" r="15" style="animation-delay: 2.96s" />
+                        <circle class="hero-net__halo" cx="760" cy="130" r="15" style="animation-delay: 3.33s" />
+                        <circle class="hero-net__halo" cx="760" cy="250" r="15" style="animation-delay: 3.70s" />
+                        <circle class="hero-net__halo" cx="760" cy="370" r="15" style="animation-delay: 4.07s" />
+                        <circle class="hero-net__halo" cx="760" cy="470" r="15" style="animation-delay: 4.44s" />
+                        <circle class="hero-net__halo" cx="1050" cy="220" r="15" style="animation-delay: 4.81s" />
+                        <circle class="hero-net__halo" cx="1050" cy="340" r="15" style="animation-delay: 5.18s" />
+                        <circle class="hero-net__core" cx="150" cy="120" r="5" style="animation-delay: 0.00s" />
+                        <circle class="hero-net__core" cx="150" cy="240" r="5" style="animation-delay: 0.37s" />
+                        <circle class="hero-net__core" cx="150" cy="360" r="5" style="animation-delay: 0.74s" />
+                        <circle class="hero-net__core" cx="150" cy="470" r="5" style="animation-delay: 1.11s" />
+                        <circle class="hero-net__core" cx="450" cy="80" r="5" style="animation-delay: 1.48s" />
+                        <circle class="hero-net__core" cx="450" cy="190" r="5" style="animation-delay: 1.85s" />
+                        <circle class="hero-net__core" cx="450" cy="300" r="5" style="animation-delay: 2.22s" />
+                        <circle class="hero-net__core" cx="450" cy="410" r="5" style="animation-delay: 2.59s" />
+                        <circle class="hero-net__core" cx="450" cy="500" r="5" style="animation-delay: 2.96s" />
+                        <circle class="hero-net__core" cx="760" cy="130" r="5" style="animation-delay: 3.33s" />
+                        <circle class="hero-net__core" cx="760" cy="250" r="5" style="animation-delay: 3.70s" />
+                        <circle class="hero-net__core" cx="760" cy="370" r="5" style="animation-delay: 4.07s" />
+                        <circle class="hero-net__core" cx="760" cy="470" r="5" style="animation-delay: 4.44s" />
+                        <circle class="hero-net__core" cx="1050" cy="220" r="5" style="animation-delay: 4.81s" />
+                        <circle class="hero-net__core" cx="1050" cy="340" r="5" style="animation-delay: 5.18s" />
+                    </g>
+                </svg>
+                <svg class="hero-ecg" viewBox="0 0 1200 120" preserveAspectRatio="none"
+                    focusable="false" role="presentation">
+                    <path class="hero-ecg__base" pathLength="1200"
+                        d="M0 60 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72" />
+                    <path class="hero-ecg__sweep" pathLength="1200"
+                        d="M0 60 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72 h100 l10 -8 l8 8 h22 l8 4 l8 -44 l8 48 l8 -8 h28 l14 -12 l14 12 h72" />
+                </svg>
             </div>
 
             <div class="container">
@@ -414,7 +487,23 @@
                             <h3>Current Focus</h3>
                             <div class="focus-items">
                                 <div class="focus-item">
-                                    <i class="fas fa-eye"></i>
+                                    <!-- Sonar rings: spatial guidance for blind and low-vision users -->
+                                    <span class="focus-glyph focus-glyph--sonar" aria-hidden="true">
+                                        <svg viewBox="0 0 48 48" focusable="false" role="presentation">
+                                            <g class="focus-glyph__rings">
+                                                <circle cx="24" cy="25" r="8" />
+                                                <circle cx="24" cy="25" r="8" style="animation-delay: 0.8s" />
+                                                <circle cx="24" cy="25" r="8" style="animation-delay: 1.6s" />
+                                            </g>
+                                            <g class="focus-glyph__figure">
+                                                <circle cx="24" cy="10" r="3.4" />
+                                                <path d="M14.5 19h19" />
+                                                <path d="M24 16.5v11" />
+                                                <path d="M24 27.5 18.5 38" />
+                                                <path d="M24 27.5 29.5 38" />
+                                            </g>
+                                        </svg>
+                                    </span>
                                     <div>
                                         <h4>Accessibility AI</h4>
                                         <p>Developing LLM-based navigation systems for individuals with visual
@@ -422,7 +511,20 @@
                                     </div>
                                 </div>
                                 <div class="focus-item">
-                                    <i class="fas fa-fire"></i>
+                                    <!-- Flame with rising embers: wildfire detection -->
+                                    <span class="focus-glyph focus-glyph--ember" aria-hidden="true">
+                                        <svg viewBox="0 0 48 48" focusable="false" role="presentation">
+                                            <g class="focus-glyph__embers">
+                                                <circle cx="16" cy="34" r="1.8" />
+                                                <circle cx="24" cy="36" r="1.4" style="animation-delay: 0.9s" />
+                                                <circle cx="32" cy="34" r="1.6" style="animation-delay: 1.7s" />
+                                            </g>
+                                            <path class="focus-glyph__flame"
+                                                d="M24 40c-6.6 0-11-4.3-11-10.4 0-7.4 6.3-11.6 8.1-21.6 4.9 3.6 6.6 8.2 6.6 11.7 1.5-1.2 2.4-3 2.6-5.3 3.1 3.4 4.7 8 4.7 12.6C35 35.4 30.6 40 24 40Z" />
+                                            <path class="focus-glyph__flame-core"
+                                                d="M24 36c-3.3 0-5.6-2.2-5.6-5.4 0-3.7 3.4-5.8 4.5-10.3 2.9 2.7 6.7 6 6.7 10.3 0 3.2-2.3 5.4-5.6 5.4Z" />
+                                        </svg>
+                                    </span>
                                     <div>
                                         <h4>Environmental AI</h4>
                                         <p>Creating Vision-Language Models for early wildfire detection and
@@ -430,7 +532,16 @@
                                     </div>
                                 </div>
                                 <div class="focus-item">
-                                    <i class="fas fa-microscope"></i>
+                                    <!-- Heartbeat trace under a sweeping scan line: medical image analysis -->
+                                    <span class="focus-glyph focus-glyph--scan" aria-hidden="true">
+                                        <svg viewBox="0 0 48 48" focusable="false" role="presentation">
+                                            <rect class="focus-glyph__monitor" x="5" y="9" width="38" height="30"
+                                                rx="5" />
+                                            <path class="focus-glyph__trace" pathLength="100"
+                                                d="M10 26h6l3-7 4 14 3-9 2 2h10" />
+                                            <line class="focus-glyph__scanline" x1="6" y1="10" x2="42" y2="10" />
+                                        </svg>
+                                    </span>
                                     <div>
                                         <h4>Medical AI</h4>
                                         <p>Advancing deep learning techniques for medical image analysis and diagnosis
@@ -444,6 +555,14 @@
                 </div>
             </div>
         </section>
+
+        <!-- Vitals divider: decorative section break on the medical theme -->
+        <div class="vitals-divider" aria-hidden="true">
+            <svg viewBox="0 0 1200 60" preserveAspectRatio="none" focusable="false" role="presentation">
+                <path class="vitals-divider__base" pathLength="1200" d="M0 30 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72" />
+                <path class="vitals-divider__sweep" pathLength="1200" d="M0 30 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72 h100 l10 -4 l8 4 h22 l8 2 l8 -22 l8 24 l8 -4 h28 l14 -6 l14 6 h72" />
+            </svg>
+        </div>
 
         <!-- Education Section -->
         <section id="education" class="section section-alt">

--- a/index.html
+++ b/index.html
@@ -441,6 +441,41 @@
             </a>
         </section>
 
+        <!-- Research at a glance. Every figure is recounted from this page's own
+             markup at runtime (see initMetricCounters in js/main.js), so a number
+             here can never drift from the section it summarises. The values in
+             the markup are the accurate no-JS fallback. -->
+        <section class="metrics-band" aria-label="Research at a glance">
+            <div class="container">
+                <ul class="metrics-grid">
+                    <li class="metric">
+                        <a class="metric__link" href="#publications">
+                            <span class="metric__value" data-count-of="#publications .publication-item">15</span>
+                            <span class="metric__label">Publications</span>
+                        </a>
+                    </li>
+                    <li class="metric">
+                        <a class="metric__link" href="#research-projects">
+                            <span class="metric__value" data-count-of="#research-projects .project-item">5</span>
+                            <span class="metric__label">Research Projects</span>
+                        </a>
+                    </li>
+                    <li class="metric">
+                        <a class="metric__link" href="#projects">
+                            <span class="metric__value" data-count-of="#projects .project-card">6</span>
+                            <span class="metric__label">Projects</span>
+                        </a>
+                    </li>
+                    <li class="metric">
+                        <a class="metric__link" href="#teaching">
+                            <span class="metric__value" data-count-of="#teaching .course-item">4</span>
+                            <span class="metric__label">Courses Taught</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </section>
+
         <!-- About Section -->
         <section id="about" class="section" aria-label="About me">
             <div class="container">

--- a/js/main.js
+++ b/js/main.js
@@ -395,6 +395,60 @@ function initLazyLoading() {
 // Performance optimizations
 function initPerformanceOptimizations() {
     initHeroParallax();
+    initHeroVizPlayback();
+    initScrollProgress();
+}
+
+// The hero visualization animates stroke offsets, which repaint rather than
+// composite. Park it whenever nobody can see it: scrolled past, or tab hidden.
+function initHeroVizPlayback() {
+    const viz = document.querySelector('.hero-viz');
+    if (!viz) return;
+
+    let onScreen = true;
+
+    const sync = () => {
+        viz.classList.toggle('is-paused', document.hidden || !onScreen);
+    };
+
+    if (supportsIntersectionObserver) {
+        new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                onScreen = entry.isIntersecting;
+            });
+            sync();
+        }, { threshold: 0 }).observe(viz);
+    }
+
+    document.addEventListener('visibilitychange', sync);
+    sync();
+}
+
+// Reading progress bar. Scaled rather than resized so the browser can keep it
+// on the compositor, and left decorative — the scrollbar already tells
+// assistive technology where we are in the document.
+function initScrollProgress() {
+    const bar = document.getElementById('scroll-progress-bar');
+    if (!bar) return;
+
+    let ticking = false;
+
+    const update = () => {
+        const scrollable = document.documentElement.scrollHeight - window.innerHeight;
+        const progress = scrollable > 0 ? Math.min(window.scrollY / scrollable, 1) : 0;
+        bar.style.transform = `scaleX(${progress})`;
+        ticking = false;
+    };
+
+    const request = () => {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(update);
+    };
+
+    window.addEventListener('scroll', request, { passive: true });
+    window.addEventListener('resize', request, { passive: true });
+    update();
 }
 
 // Subtle parallax on the hero background only, driven by requestAnimationFrame

--- a/js/main.js
+++ b/js/main.js
@@ -397,6 +397,70 @@ function initPerformanceOptimizations() {
     initHeroParallax();
     initHeroVizPlayback();
     initScrollProgress();
+    initMetricCounters();
+}
+
+// Returns true when either the OS setting or the site's own Reduce Motion
+// toggle is asking us to hold still.
+function prefersLessMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        || document.body.classList.contains('reduce-motion');
+}
+
+// The "research at a glance" figures are recounted from the page's own markup
+// rather than hard-coded, so adding a publication updates the tile for free and
+// the number can never contradict the section it links to. The value written in
+// the HTML is the no-JS fallback and is only replaced once a count succeeds.
+function initMetricCounters() {
+    const counters = document.querySelectorAll('.metric__value[data-count-of]');
+    if (!counters.length) return;
+
+    const targets = new Map();
+
+    counters.forEach(el => {
+        const total = document.querySelectorAll(el.dataset.countOf).length;
+        // A selector that matches nothing means the section was renamed or
+        // removed — keep the authored fallback rather than showing a zero.
+        if (total > 0) targets.set(el, total);
+    });
+
+    const settle = (el) => {
+        el.textContent = String(targets.get(el));
+    };
+
+    const countUp = (el) => {
+        const total = targets.get(el);
+        const duration = 900;
+        const started = performance.now();
+
+        const step = (now) => {
+            const progress = Math.min((now - started) / duration, 1);
+            const eased = 1 - Math.pow(1 - progress, 3);
+            el.textContent = String(Math.round(total * eased));
+            if (progress < 1) requestAnimationFrame(step);
+            else settle(el);
+        };
+
+        requestAnimationFrame(step);
+    };
+
+    if (!supportsIntersectionObserver || prefersLessMotion()) {
+        targets.forEach((_, el) => settle(el));
+        return;
+    }
+
+    // Start from zero only for counters we are about to animate, so a counter
+    // that never scrolls into view still shows its real figure.
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (!entry.isIntersecting) return;
+            observer.unobserve(entry.target);
+            if (prefersLessMotion()) settle(entry.target);
+            else countUp(entry.target);
+        });
+    }, { threshold: 0.4 });
+
+    targets.forEach((_, el) => observer.observe(el));
 }
 
 // The hero visualization animates stroke offsets, which repaint rather than


### PR DESCRIPTION
Replaces the hand-positioned `div` animations with purpose-built SVG that reads as the research it represents, plus a measured amount of professional polish around it.

## What changed

**Hero** — a four-layer neural graph whose edges carry travelling signal pulses, over a heartbeat trace that sweeps continuously left to right. This replaces the old absolutely-positioned `.neuron` / `.particle` divs, whose three "layers" all sat at `top: 0` and so never formed a legible network.

**About → Current Focus** — the three research pillars get bespoke animated glyphs in place of generic Font Awesome icons:

| Pillar | Glyph |
| --- | --- |
| Accessibility AI | Sonar rings expanding around the international symbol of access |
| Environmental AI | Flickering flame with rising embers |
| Medical AI | Monitor whose trace draws itself while a scan line sweeps the frame |

**Navigation** — the brand mark becomes an inline SVG neuron triad that fires in sequence (also updated on `blog-post.html`), nav links gain a sliding underline, and a thin gradient reading-progress bar tracks scroll position.

**Cards** — publications, projects, experience, news and awards get a soft band of light that crosses on hover, echoing an imaging pass. Pointer devices only, so touch users don't get a stuck highlight.

**Section break** — one quiet ECG divider between About and Education.

## Motion governance

Every animation defines its **resting state as the base style** and puts the movement in the keyframes. The site's existing `prefers-reduced-motion` and Reduce Motion overrides collapse `animation-duration` to `0.01ms`, so with that pattern they leave a complete static picture rather than a frozen or invisible element — no duplicated reduced-motion blocks needed. None of the new animations use a fill-mode, for the same reason.

The hero visualization parks itself (`.is-paused`) when scrolled out of view or the tab is hidden, since stroke-offset animation repaints rather than composites. Geometry (`r`) and plain translation are animated instead of scaled transforms, avoiding a `transform-box` dependency.

## Two bugs fixed along the way

- `.main-content` is offset by the fixed navbar, so a `100vh` hero overflowed the viewport by exactly the navbar's height — the scroll indicator was below the fold on first paint. Now `calc(100vh - var(--nav-height))`, with an `svh` variant for mobile browsers.
- The hero title's white → mid-blue gradient sat at roughly 3:1 against the navy background. The ramp now stays in the light end.

## Cleanup

Removed the CSS the new SVGs replace: `.neural-network-icon`, `.neural-layer`, `.neuron`, `.particle`, and the now-unreferenced `neuralPulse`, `neuronGlow`, `dataFlow` and `particleFloat` keyframes.

## Verification

Rendered in headless Chromium at 1440×900 and 390×844, in light and dark themes, with `prefers-reduced-motion: reduce` and with the site's own Reduce Motion toggle. Confirmed each glyph stays legible when motion is off, the card sweep drops out entirely, and the hero visualization reaches `is-paused` once scrolled away. HTML nesting validated on `index.html`, `blog.html` and `blog-post.html`. No console errors beyond the sandbox blocking the Font Awesome and Google Fonts CDNs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd5hkAmyMdugZtthgz3zxo)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ayanzadeh93/ayanzadeh93.github.io/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->